### PR TITLE
Remove update_one and delete_one

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ another database or ORM engine.
     print(result["text"])
 
     new_data = {"name": "Virgil", "text": "Hello World!"}
-    collection.update_one(new_data, name="Dante")
+    collection.update(new_data, name="Dante")
     ```
 
 Under the hood, Dante stores each dictionary in a JSON-encoded TEXT column
@@ -79,7 +79,7 @@ print(result.text)
 # Find a model in the collection with the attribute name=Dante
 # and update (overwrite) it with the new model data
 result.name = "Virgil"
-collection.update_one(result, name="Dante")
+collection.update(result, name="Dante")
 ```
 
 ## Aync Dante
@@ -102,7 +102,7 @@ async def main():
     print(result["text"])
 
     new_data = {"name": "Virgil", "text": "Hello World!"}
-    await collection.update_one(new_data, name="Dante")
+    await collection.update(new_data, name="Dante")
 
     await db.close()
 

--- a/dante/asyncdante.py
+++ b/dante/asyncdante.py
@@ -76,7 +76,7 @@ class Collection(BaseCollection):
         results = await _self.find_many(1, **kwargs)
         return results[0] if len(results) > 0 else None
 
-    async def update_many(
+    async def update(
         _self,
         _data: dict | BaseModel,
         _limit: int | None = None,
@@ -90,15 +90,12 @@ class Collection(BaseCollection):
 
         conn: aiosqlite.Connection = await _self.db.get_connection()
         await conn.execute(
-            f"UPDATE {_self.name} SET data = ? {query}",
+            f"UPDATE {_self.name} SET data = ?{query}",
             (_self._to_json(_data), *values),
         )
         await _self.db._maybe_commit()
 
-    async def update_one(_self, _data: dict | BaseModel, /, **kwargs: Any):
-        await _self.update_many(_data, None, **kwargs)
-
-    async def delete_many(_self, _limit: int | None = None, /, **kwargs: Any):
+    async def delete(_self, _limit: int | None = None, /, **kwargs: Any):
         if not kwargs:
             raise ValueError("You must provide a filter to delete")
 
@@ -107,9 +104,6 @@ class Collection(BaseCollection):
         conn: aiosqlite.Connection = await _self.db.get_connection()
         await conn.execute(f"DELETE FROM {_self.name}{query}", values)
         await _self.db._maybe_commit()
-
-    async def delete_one(_self, /, **kwargs: Any):
-        await _self.delete_many(None, **kwargs)
 
     async def clear(self):
         conn: aiosqlite.Connection = await self.db.get_connection()

--- a/dante/base.py
+++ b/dante/base.py
@@ -184,7 +184,8 @@ class BaseCollection(ABC):
             query = ""
 
         if _limit:
-            query += f" LIMIT {_limit}"
+            query += " LIMIT ?"
+            values.append(_limit)
 
         return query, values
 
@@ -224,7 +225,7 @@ class BaseCollection(ABC):
         """
 
     @abstractmethod
-    def update_many(
+    def update(
         _self,
         _data: dict | BaseModel,
         _limit: int | None = None,
@@ -242,31 +243,12 @@ class BaseCollection(ABC):
         """
 
     @abstractmethod
-    def update_one(_self, _data: dict | BaseModel, /, **kwargs: Any):
-        """
-        Update one document matching the query.
-
-        Note that the data must be a full object, not just the fields to update.
-
-        :param _data: Data to update with (must be a full object)
-        :param kwargs: Fields to match in the document
-        """
-
-    @abstractmethod
-    def delete_many(_self, _limit: int | None = None, /, **kwargs: Any):
+    def delete(_self, _limit: int | None = None, /, **kwargs: Any):
         """
         Delete documents matching the query.
 
         :param _limit: Maximum number of documents to delete (default is no limit)
         :param kwargs: Fields to match in the documents
-        """
-
-    @abstractmethod
-    def delete_one(_self, /, **kwargs: Any):
-        """
-        Delete one document matching the query.
-
-        :param kwargs: Fields to match in the document
         """
 
     @abstractmethod

--- a/dante/sync.py
+++ b/dante/sync.py
@@ -89,7 +89,7 @@ class Collection(BaseCollection):
         results = _self.find_many(1, **kwargs)
         return results[0] if len(results) > 0 else None
 
-    def update_many(
+    def update(
         _self,
         _data: dict | BaseModel,
         _limit: int | None = None,
@@ -108,10 +108,7 @@ class Collection(BaseCollection):
         )
         _self.db._maybe_commit()
 
-    def update_one(_self, _data: dict | BaseModel, /, **kwargs: Any):
-        _self.update_many(_data, 1, **kwargs)
-
-    def delete_many(_self, _limit: int | None = None, /, **kwargs: Any):
+    def delete(_self, _limit: int | None = None, /, **kwargs: Any):
         if not kwargs:
             raise ValueError("You must provide a filter to delete")
 
@@ -120,9 +117,6 @@ class Collection(BaseCollection):
         cursor = _self.conn.cursor()
         cursor.execute(f"DELETE FROM {_self.name}{query}", values)
         _self.db._maybe_commit()
-
-    def delete_one(_self, /, **kwargs: Any):
-        _self.delete_many(1, **kwargs)
 
     def clear(self):
         cursor = self.conn.cursor()

--- a/tests/test_async_models.py
+++ b/tests/test_async_models.py
@@ -51,7 +51,7 @@ async def test_update_model(db):
     await coll.insert(obj)
 
     obj.b = "bar"
-    await coll.update_many(obj, a=1)
+    await coll.update(obj, a=1)
 
     result = await coll.find_one(a=1)
     assert isinstance(result, MyModel)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,7 @@ def test_update_model():
     coll.insert(obj)
 
     obj.b = "bar"
-    coll.update_many(obj, a=1)
+    coll.update(obj, a=1)
 
     result = coll.find_one(a=1)
     assert isinstance(result, MyModel)
@@ -69,7 +69,7 @@ def test_update_without_filter_fails():
     obj = MyModel(a=1)
 
     with pytest.raises(ValueError):
-        coll.update_many(obj)
+        coll.update(obj)
 
 
 def test_delete_without_filter_fails():
@@ -77,4 +77,4 @@ def test_delete_without_filter_fails():
     coll = db[MyModel]
 
     with pytest.raises(ValueError):
-        coll.delete_many()
+        coll.delete()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -78,23 +78,12 @@ def test_find_none():
     assert result is None
 
 
-def test_update_one():
+def test_update():
     db = Dante()
     coll = db["test"]
 
     coll.insert({"a": 1, "b": 2})
-    coll.insert({"a": 1, "b": 3})
-    coll.update_one({"a": 1, "b": 4}, a=1)
-    result_bs = set(r["b"] for r in coll)
-    assert result_bs == {2, 4} or result_bs == {3, 4}
-
-
-def test_update_many():
-    db = Dante()
-    coll = db["test"]
-
-    coll.insert({"a": 1, "b": 2})
-    coll.update_many({"a": 1, "b": 3}, a=1)
+    coll.update({"a": 1, "b": 3}, a=1)
     result = coll.find_one(a=1)
     assert result["b"] == 3
 
@@ -103,27 +92,16 @@ def test_update_without_filter_fails():
     db = Dante()
     coll = db["test"]
     with pytest.raises(ValueError):
-        coll.update_many({})
+        coll.update({})
 
 
-def test_delete_one():
-    db = Dante()
-    coll = db["test"]
-
-    coll.insert({"a": 1, "b": 2})
-    coll.insert({"a": 1, "b": 2})
-    coll.delete_one(a=1)
-    result = coll.find_many(a=1)
-    assert len(result) == 1
-
-
-def test_delete_many():
+def test_delete():
     db = Dante()
     coll = db["test"]
 
     coll.insert({"a": 1, "b": 2})
     coll.insert({"a": 1, "b": 3})
-    coll.delete_many(a=1)
+    coll.delete(a=1)
     result = coll.find_many(a=1)
     assert result == []
 
@@ -132,9 +110,7 @@ def test_delete_without_filter_fails():
     db = Dante()
     coll = db["test"]
     with pytest.raises(ValueError):
-        coll.delete_many()
-    with pytest.raises(ValueError):
-        coll.delete_one()
+        coll.delete()
 
 
 def test_clear():
@@ -159,24 +135,6 @@ def test_insert_performance(tmp_path):
     t1 = time()
     dt = t1 - t0
     assert dt < 0.05
-
-
-def test_update_performance(tmp_path):
-    db_path = tmp_path / "test.db"
-    db = Dante(db_path, auto_commit=False)
-
-    coll = db["test"]
-    for i in range(100):
-        coll.insert({"a": i, "b": i + 1})
-
-    db.commit()
-    t0 = time()
-    for i in range(100):
-        coll.update_one({"a": i, "b": 2 * i + 1}, a=i)
-    db.commit()
-    t1 = time()
-    dt = t1 - t0
-    assert dt < 0.1
 
 
 def test_str():


### PR DESCRIPTION
SQLite support for LIMIT in UPDATE and DELETE clauses is optional (see [SQLITE_ENABLE_UPDATE_DELETE_LIMIT](https://www.sqlite.org/compile.html) compile-time flag). Rather than working around it, we just remove the support for this.

As we don't guarantee ordering, those two methods are bad API anyways.