### PR TITLE
Always use JSON path for nested filters

### DIFF
--- a/dante/base.py
+++ b/dante/base.py
@@ -177,7 +177,7 @@ class BaseCollection(ABC):
         if kwargs:
             query_parts = []
             for key, value in kwargs.items():
-                key = key.replace("__", ".")
+                key = "$." + key.replace("__", ".")
                 query_parts.append("data->>? = ?")
                 values.extend([key, value])
             query = " WHERE " + " AND ".join(query_parts)


### PR DESCRIPTION
Hopefully this will work around different JSON path syntax support across different Python/SQlite builds.